### PR TITLE
Fix the joystick out of bounds error

### DIFF
--- a/src/main/java/com/frc5113/library/oi/Dpad.java
+++ b/src/main/java/com/frc5113/library/oi/Dpad.java
@@ -60,6 +60,6 @@ public class Dpad {
      * @return scalar of POV hat
      */
     public double getValue() {
-        return joy.getRawAxis(axis.value);
+        return joy.getRawAxis(axis.getValue());
     }
 }

--- a/src/main/java/com/frc5113/library/oi/buttons/AxisButton.java
+++ b/src/main/java/com/frc5113/library/oi/buttons/AxisButton.java
@@ -26,7 +26,7 @@ public class AxisButton extends Button {
     }
 
     public AxisButton(GenericHID joystick, Axis axis, double threshold, ThresholdType thresholdType) {
-        this(joystick, axis.value, threshold, thresholdType);
+        this(joystick, axis.getValue(), threshold, thresholdType);
     }
 
 

--- a/src/main/java/com/frc5113/library/oi/generic/SimpleGenericController.java
+++ b/src/main/java/com/frc5113/library/oi/generic/SimpleGenericController.java
@@ -1,10 +1,10 @@
 package com.frc5113.library.oi.generic;
 
-import edu.wpi.first.wpilibj.Joystick;
+import edu.wpi.first.wpilibj.GenericHID;
 import edu.wpi.first.wpilibj2.command.button.Button;
 import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 
-public class SimpleGenericController extends Joystick {
+public class SimpleGenericController extends GenericHID {
     /**
      * Create a new Simple Generic Controller
      * @param port DS port (indicated in controller settings / preview)

--- a/src/main/java/com/frc5113/library/oi/sticks/Slider.java
+++ b/src/main/java/com/frc5113/library/oi/sticks/Slider.java
@@ -23,7 +23,7 @@ public class Slider {
     public double getValue() {
         double value = 0;
         if (this.controller.isConnected()){
-            value = this.controller.getRawAxis(slider.value);
+            value = this.controller.getRawAxis(slider.getValue());
             value = curve.calculateMappedVal(value);
         }
         return value;

--- a/src/main/java/com/frc5113/library/oi/sticks/Stick.java
+++ b/src/main/java/com/frc5113/library/oi/sticks/Stick.java
@@ -28,7 +28,7 @@ public class Stick extends ThumbStick {
     public double getTwist() {
         double value = 0;
         if (this.controller.isConnected()){
-            value = this.controller.getRawAxis(twistAxis.value);
+            value = this.controller.getRawAxis(twistAxis.getValue());
             value = twistCurve.calculateMappedVal(value);
         }
         return value;

--- a/src/main/java/com/frc5113/library/oi/sticks/ThumbStick.java
+++ b/src/main/java/com/frc5113/library/oi/sticks/ThumbStick.java
@@ -18,7 +18,7 @@ public class ThumbStick {
     public final Curve xCurve;
     public final Curve yCurve;
 
-    public ThumbStick(Joystick controller, Axis xAxis, Axis yAxis) {
+    public ThumbStick(GenericHID controller, Axis xAxis, Axis yAxis) {
         this.controller = controller;
         this.xAxis = xAxis;
         this.yAxis = yAxis;
@@ -39,7 +39,7 @@ public class ThumbStick {
     public double getX() {
         double value = 0;
         if (this.controller.isConnected()){
-            value = this.controller.getRawAxis(xAxis.value);
+            value = this.controller.getRawAxis(xAxis.getValue());
             value = xCurve.calculateMappedVal(value);
         }
         return value;
@@ -48,7 +48,7 @@ public class ThumbStick {
     public double getY() {
         double value = 0;
         if (this.controller.isConnected()){
-            value = this.controller.getRawAxis(yAxis.value);
+            value = this.controller.getRawAxis(yAxis.getValue());
             value = yCurve.calculateMappedVal(value);
         }
         return  value;

--- a/src/main/java/com/frc5113/library/oi/xbox/XboxGamepad.java
+++ b/src/main/java/com/frc5113/library/oi/xbox/XboxGamepad.java
@@ -177,8 +177,8 @@ public class XboxGamepad extends XboxController {
     }
 
     /**
-     * The axis numerations of the XBox controller
-     * @implNote should be equivalent to <a href="https://github.wpilib.org/allwpilib/docs/release/java/src-html/edu/wpi/first/wpilibj/XboxController.html#line.57">...</a>
+     * The axis numerations of the XBox controller.
+     * Should be equivalent to <a href="https://github.wpilib.org/allwpilib/docs/release/java/src-html/edu/wpi/first/wpilibj/XboxController.html#line.57">WPI Impl</a>
      */
     public enum XboxAxis implements com.frc5113.library.primative.Axis {
         leftX(0),

--- a/src/main/java/com/frc5113/library/oi/xbox/XboxGamepad.java
+++ b/src/main/java/com/frc5113/library/oi/xbox/XboxGamepad.java
@@ -2,7 +2,6 @@ package com.frc5113.library.oi.xbox;
 
 import com.frc5113.library.oi.Dpad;
 import com.frc5113.library.oi.buttons.AxisButton;
-import com.frc5113.library.oi.buttons.Button;
 import com.frc5113.library.oi.scalers.SmoothCubicCurve;
 import com.frc5113.library.oi.scalers.Curve;
 import com.frc5113.library.oi.scalers.NoOpCurve;
@@ -21,7 +20,7 @@ public class XboxGamepad extends XboxController {
 
     public Curve lxCurve;
     public Curve lyCurve;
-    public Curve rxCurve; 
+    public Curve rxCurve;
     public Curve ryCurve; 
 
     public com.frc5113.library.oi.buttons.Button xButton = new com.frc5113.library.oi.buttons.Button(this, XboxButton.X);
@@ -56,7 +55,7 @@ public class XboxGamepad extends XboxController {
         lxCurve = noOp;
         lyCurve = noOp;
         rxCurve = noOp;
-        rxCurve = noOp;
+        ryCurve = noOp;
     }
 
     /**
@@ -177,7 +176,10 @@ public class XboxGamepad extends XboxController {
         }
     }
 
-
+    /**
+     * The axis numerations of the XBox controller
+     * @implNote should be equivalent to <a href="https://github.wpilib.org/allwpilib/docs/release/java/src-html/edu/wpi/first/wpilibj/XboxController.html#line.57">...</a>
+     */
     public enum XboxAxis implements com.frc5113.library.primative.Axis {
         leftX(0),
         leftY(1),

--- a/src/main/java/com/frc5113/library/primative/Axis.java
+++ b/src/main/java/com/frc5113/library/primative/Axis.java
@@ -1,8 +1,6 @@
 package com.frc5113.library.primative;
 
 public interface Axis {
-    int value = -1;
-
     public Axis fromValue(int mValue);
 
     int getValue();


### PR DESCRIPTION
Error message:
```
Unhandled exception: java.lang.IllegalArgumentException: Joystick axis is out of range
Error at com.frc5113.library.oi.sticks.ThumbStick.getY(ThumbStick.java:51): Unhandled exception: 
java.lang.IllegalArgumentException: Joystick axis is out of range

at edu.wpi.first.wpilibj.DriverStation.getStickAxis(DriverStation.java:715)
at edu.wpi.first.wpilibj.GenericHID.getRawAxis(GenericHID.java:129)
The robot program quit unexpectedly. This is usually due to a code error.
The above stacktrace can help determine where the error occurred.
See https://wpilib.org/stacktrace for more information.
at com.frc5113.library.oi.sticks.ThumbStick.getY(ThumbStick.java:51)
at frc.robot.RobotContainer.getControllerLeftY(RobotContainer.java:90)
at frc.robot.Robot.lambda$teleopInit$3(Robot.java:111)
at frc.robot.commands.DriveCommand.execute(DriveCommand.java:37)
at edu.wpi.first.wpilibj2.command.CommandScheduler.run(CommandScheduler.java:280)
at frc.robot.Robot.robotPeriodic(Robot.java:54)
at edu.wpi.first.wpilibj.IterativeRobotBase.loopFunc(IterativeRobotBase.java:328)
at edu.wpi.first.wpilibj.TimedRobot.startCompetition(TimedRobot.java:131)
at edu.wpi.first.wpilibj.RobotBase.runRobot(RobotBase.java:373)
at edu.wpi.first.wpilibj.RobotBase.startRobot(RobotBase.java:463)
at frc.robot.Main.main(Main.java:26)
The startCompetition() method (or methods called by it) should have handled the exception above.
   from: edu.wpi.first.wpilibj.RobotBase.runRobot(RobotBase.java:395)

Warning at edu.wpi.first.wpilibj.RobotBase.runRobot(RobotBase.java:388): The robot program quit unexpectedly. This is usually due to a code error.
The above stacktrace can help determine where the error occurred.
See https://wpilib.org/stacktrace for more information.
Error at edu.wpi.first.wpilibj.RobotBase.runRobot(RobotBase.java:395): The startCompetition() method (or methods called by it) should have handled the exception above.
```

Changes (currently - proposed):

- Convert Axis interface from implicit value to only use .getValue() calls

**Not complete - still requires robot testing**